### PR TITLE
Enhancement: Use `PHP_FLOAT_EPSILON`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`1.0.0...main`][1.0.0...main].
 ### Changed
 
 - Dropped support for PHP 7.3 ([#21]), by [@localheinz]
+- Started using `PHP_FLOAT_EPSILON` instead of `0.1` in `FloatProvider` ([#23]), by [@localheinz]
 
 ## [`1.0.0`][1.0.0]
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -13,6 +13,9 @@
     </MoreSpecificReturnType>
   </file>
   <file src="src/FloatProvider.php">
+    <InvalidOperand occurrences="1">
+      <code>-1 * \PHP_FLOAT_EPSILON</code>
+    </InvalidOperand>
     <MoreSpecificReturnType occurrences="7">
       <code>\Generator&lt;string, array{0: float}&gt;</code>
       <code>\Generator&lt;string, array{0: float}&gt;</code>

--- a/src/FloatProvider.php
+++ b/src/FloatProvider.php
@@ -91,11 +91,11 @@ final class FloatProvider extends AbstractProvider
         $faker = self::faker();
 
         return [
-            'float-less-than-minus-one' => -0.01 - $faker->randomFloat(null, 1),
+            'float-less-than-minus-one' => (-1 * \PHP_FLOAT_EPSILON) - $faker->randomFloat(null, 1),
             'float-minus-one' => -1.0,
             'float-zero' => 0.0,
             'float-plus-one' => 1.0,
-            'float-greater-than-plus-one' => 0.01 + $faker->randomFloat(null, 1),
+            'float-greater-than-plus-one' => \PHP_FLOAT_EPSILON + $faker->randomFloat(null, 1),
         ];
     }
 }


### PR DESCRIPTION
This pull request

- [x] uses `PHP_FLOAT_EPSILON` in the `FloatProvider`

Follows https://github.com/sebastianbergmann/phpunit/pull/4874.

h/t @marijnvanwezel