### PR TITLE
Fix: Remove `StringProvider::uuid()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.0.0...main`][2.0.0...main].
 
+### Removed
+
+- Removed `StringProvider::uuid()` ([#244]), by [@localheinz]
+
 ## [`2.0.0`][2.0.0]
 
 For a full diff see [`1.3.0...2.0.0`][1.3.0...2.0.0].
@@ -77,5 +81,6 @@ For a full diff see [`a5f2657...1.0.0`][a5f2657...1.0.0].
 [#119]: https://github.com/ergebnis/data-provider/pull/119
 [#226]: https://github.com/ergebnis/data-provider/pull/226
 [#230]: https://github.com/ergebnis/data-provider/pull/230
+[#244]: https://github.com/ergebnis/data-provider/pull/244
 
 [@localheinz]: https://github.com/localheinz

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.13.0@a0a9c27630bcf8301ee78cb06741d2907d8c9fef">
+<files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
   <file src="src/AbstractProvider.php">
     <MixedAssignment>
       <code>$value</code>
@@ -54,7 +54,6 @@
   </file>
   <file src="src/StringProvider.php">
     <MixedReturnTypeCoercion>
-      <code><![CDATA[\Generator<string, array{0: string}>]]></code>
       <code><![CDATA[\Generator<string, array{0: string}>]]></code>
       <code><![CDATA[\Generator<string, array{0: string}>]]></code>
       <code><![CDATA[\Generator<string, array{0: string}>]]></code>

--- a/src/StringProvider.php
+++ b/src/StringProvider.php
@@ -69,16 +69,6 @@ final class StringProvider extends AbstractProvider
     /**
      * @return \Generator<string, array{0: string}>
      */
-    public static function uuid(): \Generator
-    {
-        yield from self::provideDataForValuesWhere(self::values(), static function (string $value): bool {
-            return 1 === \preg_match('/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i', $value);
-        });
-    }
-
-    /**
-     * @return \Generator<string, array{0: string}>
-     */
     public static function withWhitespace(): \Generator
     {
         yield from self::provideDataForValuesWhere(self::values(), static function (string $value): bool {
@@ -113,11 +103,6 @@ final class StringProvider extends AbstractProvider
 
         $emptyValues = [
             'string-empty' => '',
-        ];
-
-        $uuidValues = [
-            'string-uuid-case-lower' => \strtolower($faker->uuid()),
-            'string-uuid-case-upper' => \strtoupper($faker->uuid()),
         ];
 
         $untrimmedValues = \array_combine(
@@ -166,7 +151,6 @@ final class StringProvider extends AbstractProvider
             $blankValues,
             $emptyValues,
             $untrimmedValues,
-            $uuidValues,
             $withWhitespaceValues,
         );
     }

--- a/test/Unit/StringProviderTest.php
+++ b/test/Unit/StringProviderTest.php
@@ -46,8 +46,6 @@ final class StringProviderTest extends AbstractProviderTestCase
             'string-untrimmed-line-feed' => Test\Util\Specification\Pattern::create('/^\n{1,5}\w+\n{1,5}$/'),
             'string-untrimmed-space' => Test\Util\Specification\Pattern::create('/^\s{1,5}\w+\s{1,5}$/'),
             'string-untrimmed-tab' => Test\Util\Specification\Pattern::create('/^\t{1,5}\w+\t{1,5}$/'),
-            'string-uuid-case-lower' => Test\Util\Specification\Pattern::create('/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/'),
-            'string-uuid-case-upper' => Test\Util\Specification\Pattern::create('/^[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}$/'),
             'string-with-whitespace-carriage-return' => Test\Util\Specification\Pattern::create('/^\w+(\r+\w+){1,4}$/'),
             'string-with-whitespace-line-feed' => Test\Util\Specification\Pattern::create('/^\w+(\n+\w+){1,4}$/'),
             'string-with-whitespace-space' => Test\Util\Specification\Pattern::create('/^\w+(\s+\w+){1,4}$/'),
@@ -120,8 +118,6 @@ final class StringProviderTest extends AbstractProviderTestCase
             'string-arbitrary-word' => Test\Util\Specification\Closure::create(static function (string $value): bool {
                 return '' !== $value && '' !== \trim($value);
             }),
-            'string-uuid-case-lower' => Test\Util\Specification\Pattern::create('/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/'),
-            'string-uuid-case-upper' => Test\Util\Specification\Pattern::create('/^[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}$/'),
             'string-with-whitespace-carriage-return' => Test\Util\Specification\Pattern::create('/^\w+(\r+\w+){1,4}$/'),
             'string-with-whitespace-line-feed' => Test\Util\Specification\Pattern::create('/^\w+(\n+\w+){1,4}$/'),
             'string-with-whitespace-space' => Test\Util\Specification\Pattern::create('/^\w+(\s+\w+){1,4}$/'),
@@ -143,18 +139,6 @@ final class StringProviderTest extends AbstractProviderTestCase
         ];
 
         $provider = StringProvider::untrimmed();
-
-        self::assertProvidesDataSetsForValuesSatisfyingSpecifications($specifications, $provider);
-    }
-
-    public function testUuidReturnsGeneratorThatProvidesUuidStrings(): void
-    {
-        $specifications = [
-            'string-uuid-case-lower' => Test\Util\Specification\Pattern::create('/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/'),
-            'string-uuid-case-upper' => Test\Util\Specification\Pattern::create('/^[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}$/'),
-        ];
-
-        $provider = StringProvider::uuid();
 
         self::assertProvidesDataSetsForValuesSatisfyingSpecifications($specifications, $provider);
     }


### PR DESCRIPTION
This pull request

- [x] removes `StringProvider::uuid()`

Follows https://github.com/ergebnis/data-provider/pull/230.

🤦‍♂️