### PR TITLE
Fix: Run tests on PHP 8.3

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -27,6 +27,9 @@ branches:
           - context: "Tests (8.2, highest)"
           - context: "Tests (8.2, locked)"
           - context: "Tests (8.2, lowest)"
+          - context: "Tests (8.3, highest)"
+          - context: "Tests (8.3, locked)"
+          - context: "Tests (8.3, lowest)"
         strict: false
       restrictions:
 

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -427,6 +427,7 @@ jobs:
         php-version:
           - "8.1"
           - "8.2"
+          - "8.3"
 
         dependencies:
           - "lowest"


### PR DESCRIPTION
This pull request

- [x] runs tests on PHP 8.3

Follows #315.